### PR TITLE
Revert to use 6.0.6 and latest p.restapi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ DISTRIBUTIONS="voltolighttheme"
 IMAGE_NAME=ghcr.io/kitconcept/voltolighttheme
 IMAGE_TAG=latest
 
-PLONE6=6.0.7
-PLONE_VERSION=6
+PLONE6=6.0.6
+PLONE_VERSION=6.0.6
 SEED=$$(date +'%Y%m%d-%H%M%S')
 
 # Python checks

--- a/mx.ini
+++ b/mx.ini
@@ -5,8 +5,8 @@
 
 [settings]
 ; example how to override a package version
-; version-overrides =
-;     example.package==2.1.0a2
+version-overrides =
+    plone.restapi==9.0.0
 
 ; example section to use packages from git
 ; [example.contenttype]

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -1,1 +1,2 @@
 src/kitconcept.voltolighttheme
+plone.restapi==9.0.0


### PR DESCRIPTION
@ericof remember that I told you yesterday about the broken images and the light-theme site? 6.0.7 is to blame.

```
2023-09-29 10:16:20 ERROR [ZODB.ConflictResolution:307][waitress-0] Unexpected error while trying to resolve conflict on <class 'plone.scale.storage.ScalesDict'>
Traceback (most recent call last):
  File "/app/lib/python3.11/site-packages/ZODB/ConflictResolution.py", line 290, in tryToResolveConflict
    resolved = resolve(old, committed, newstate)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/lib/python3.11/site-packages/plone/scale/storage.py", line 119, in _p_resolveConflict
    self.raise_conflict(saved[key], new[key])
                        ~~~~~^^^^^
KeyError: 'image-1000-ab703699e343ff030a3cc014950e6ada'
```

in 6.0.6 it does not happens.

/cc @davisagli